### PR TITLE
Aumentando python mínimo pra 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
 jobs:
   test:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.8
     steps:
       - checkout
       - run:

--- a/Pipfile
+++ b/Pipfile
@@ -11,14 +11,14 @@ asynctest = "==0.12.1"
 pytest = "==5.2.1"
 pytest-cov = "==2.8.1"
 codecov = "==2.0.15"
-mypy = "==0.630"
+mypy = "==0.782"
 black = "==18.9b0"
 isort = {extras = ["pipfile"],version = "==4.3.15"}
 python-boilerplate = {editable = true,path = "."}
 lxml = "==4.4.1"
 
 [requires]
-python_version = "3.7"
+python_version = "3.8"
 
 [scripts]
 test = "py.test -v --cov=myproj --cov-report term-missing -v"

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pydantic = "==0.30.1"
+pydantic = "==1.6.1"
 
 [dev-packages]
 asynctest = "==0.12.1"


### PR DESCRIPTION
mypy usa typed-ast e o `mypy==0.630` usava uma versão do typed-ast que
não compilava no Python 3.8.
