### PR TITLE
Movendo config.py pra dentro da pasta do projeto

### DIFF
--- a/myproj/config.py
+++ b/myproj/config.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 from pydantic import BaseSettings
 
@@ -18,9 +17,7 @@ class Settings(BaseSettings):
     DEBUG: bool = True
 
     class Config:
-        env_prefix = (
-            os.getenv("NAMESPACE", "DEV").upper() + "_"
-        )  # defaults to 'APP_'
+        env_prefix = os.getenv("NAMESPACE", "DEV").upper() + "_"
 
 
 settings = Settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+import os
+from importlib import reload
+
+from asynctest import TestCase, mock
+
+from myproj import config
+
+
+class ConfigTest(TestCase):
+    async def test_debug_is_false(self):
+        with mock.patch.dict(os.environ, DEV_DEBUG="0"):
+            s = config.Settings()
+            self.assertEqual(s.DEBUG, False)
+
+    async def test_other_namespace(self):
+        with mock.patch.dict(os.environ, NAMESPACE="PROD", PROD_DEBUG="0"):
+            reload(config)
+            s = config.Settings()
+            self.assertEqual(s.DEBUG, False)


### PR DESCRIPTION
Geralmente todo o código do projeto está dentro dessa pasta. Até porque
no momento de fazer pip install esse arquivo deve ir junto.
