### PR TITLE
Fix #44 adicionando o noeme do repositorio corretamnete para o releas…

### DIFF
--- a/{{cookiecutter.project_name}}/.github/release-drafter.yml
+++ b/{{cookiecutter.project_name}}/.github/release-drafter.yml
@@ -24,6 +24,6 @@ template: |
 
   $CHANGES
 
-  Docs: https://github.com/sixcodes/python-boilerplate
-  Commits: https://github.com/sixcodes/python-boilerplate/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
-  Tag: https://github.com/sixcodes/python-boilerplate/releases/tag/$RESOLVED_VERSION
+  Docs: https://github.com/{{cookiecutter.author_username}}/{{cookiecutter.project_name}}
+  Commits: https://github.com/{{cookiecutter.author_username}}/{{cookiecutter.project_name}}/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
+  Tag: https://github.com/{{cookiecutter.author_username}}/{{cookiecutter.project_name}}/releases/tag/$RESOLVED_VERSION


### PR DESCRIPTION
# Descrição da mudança
Tinha um problema de hardcode nos nomes do repositorio

# Passos para um QA Manual
 - clonar o repositorio usando cookiecutter e validar que as variaveis foram preenchidas no `.github/release-draft.yaml`
 
# Riscos
 - continuar hard coded
 
# Passo a passo para reverter
 - Resetar a branch
